### PR TITLE
Upgrade SenseNet.Client reference and some fixes

### DIFF
--- a/src/SenseNet.IO.CLI/Properties/launchSettings.json
+++ b/src/SenseNet.IO.CLI/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "SenseNet.IO.CLI": {
       "commandName": "Project",
-      "commandLineArgs": "EXPORT -SOURCE -PATH /Root/IMS",
+      "commandLineArgs": "EXPORT --DISPLAY:LEVEL Verbose -SOURCE \"https://snbooking.sensenet.cloud/\" \"/Root\" -CLIENTID \"cYXY6wSOzXpreooq\" -CLIENTSECRET \"u1yXSA1JTVLajnREu9Qkcs5di6zweHUOQh7EMwJQeJIUDmG2OQL9YsFuluED3xu1\" -TARGET \"D:\\dev\\_snio\\snbooking.sensenet.cloud\\export\"",
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "Development"
       }

--- a/src/SenseNet.IO.CLI/Properties/launchSettings.json
+++ b/src/SenseNet.IO.CLI/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "SenseNet.IO.CLI": {
       "commandName": "Project",
-      "commandLineArgs": "EXPORT --DISPLAY:LEVEL Verbose -SOURCE \"https://snbooking.sensenet.cloud/\" \"/Root\" -CLIENTID \"cYXY6wSOzXpreooq\" -CLIENTSECRET \"u1yXSA1JTVLajnREu9Qkcs5di6zweHUOQh7EMwJQeJIUDmG2OQL9YsFuluED3xu1\" -TARGET \"D:\\dev\\_snio\\snbooking.sensenet.cloud\\export\"",
+      "commandLineArgs": "EXPORT -SOURCE -PATH /Root/IMS",
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "Development"
       }

--- a/src/SenseNet.IO.CLI/SenseNet.IO.CLI.csproj
+++ b/src/SenseNet.IO.CLI/SenseNet.IO.CLI.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="SenseNet.Client" Version="3.0.7" />
+    <PackageReference Include="SenseNet.Client" Version="4.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />

--- a/src/SenseNet.IO.DemoConsole/SenseNet.IO.DemoConsole.csproj
+++ b/src/SenseNet.IO.DemoConsole/SenseNet.IO.DemoConsole.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="SenseNet.Client" Version="3.0.7" />
+		<PackageReference Include="SenseNet.Client" Version="4.0.0" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />

--- a/src/SenseNet.IO.Tests/FsReaderTests.cs
+++ b/src/SenseNet.IO.Tests/FsReaderTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -105,6 +106,8 @@ namespace SenseNet.IO.Tests
         }
         #endregion
 
+        private readonly CancellationToken _cancel = CancellationToken.None;
+
         [TestMethod]
         public async Task FsReader_Read_RootFileOnly()
         {
@@ -142,7 +145,7 @@ namespace SenseNet.IO.Tests
             Assert.AreEqual("Root", content.Name);
             Assert.AreEqual("PortalRoot", content.Type);
             Assert.AreEqual(0, content.FieldNames.Length);
-            Assert.AreEqual(0, (await content.GetAttachmentsAsync()).Length);
+            Assert.AreEqual(0, (await content.GetAttachmentsAsync(_cancel)).Length);
             Assert.AreEqual(true, content.Permissions.IsInherited);
             Assert.AreEqual(1, content.Permissions.Entries.Length);
         }
@@ -184,7 +187,7 @@ namespace SenseNet.IO.Tests
             Assert.AreEqual("Root", content.Name);
             Assert.AreEqual("PortalRoot", content.Type);
             Assert.AreEqual(0, content.FieldNames.Length);
-            Assert.AreEqual(0, (await content.GetAttachmentsAsync()).Length);
+            Assert.AreEqual(0, (await content.GetAttachmentsAsync(_cancel)).Length);
             Assert.AreEqual(true, content.Permissions.IsInherited);
             Assert.AreEqual(1, content.Permissions.Entries.Length);
         }
@@ -230,7 +233,7 @@ namespace SenseNet.IO.Tests
             Assert.AreEqual(1, content.FieldNames.Length);
             Assert.AreEqual("Type", content.FieldNames[0]);
             Assert.AreEqual("ContentType1", content["Type"]);
-            Assert.AreEqual(0, (await content.GetAttachmentsAsync()).Length);
+            Assert.AreEqual(0, (await content.GetAttachmentsAsync(_cancel)).Length);
             Assert.AreEqual(true, content.Permissions.IsInherited);
             Assert.AreEqual(1, content.Permissions.Entries.Length);
         }
@@ -276,7 +279,7 @@ namespace SenseNet.IO.Tests
             Assert.AreEqual(1, content.FieldNames.Length);
             Assert.AreEqual("Type", content.FieldNames[0]);
             Assert.AreEqual("ContentType_Irrelevant", content["Type"]);
-            Assert.AreEqual(0, (await content.GetAttachmentsAsync()).Length);
+            Assert.AreEqual(0, (await content.GetAttachmentsAsync(_cancel)).Length);
             Assert.AreEqual(true, content.Permissions.IsInherited);
             Assert.AreEqual(1, content.Permissions.Entries.Length);
         }
@@ -320,7 +323,7 @@ namespace SenseNet.IO.Tests
             Assert.AreEqual("Root", content.Name);
             Assert.AreEqual("PortalRoot", content.Type);
             Assert.AreEqual(0, content.FieldNames.Length);
-            Assert.AreEqual(0, (await content.GetAttachmentsAsync()).Length);
+            Assert.AreEqual(0, (await content.GetAttachmentsAsync(_cancel)).Length);
             Assert.AreEqual(null, content.Permissions);
 
             Assert.AreEqual("F1", contents[1].Key);
@@ -328,7 +331,7 @@ namespace SenseNet.IO.Tests
             Assert.AreEqual("F1", content.Name);
             Assert.AreEqual("Folder", content.Type);
             Assert.AreEqual(0, content.FieldNames.Length);
-            Assert.AreEqual(0, (await content.GetAttachmentsAsync()).Length);
+            Assert.AreEqual(0, (await content.GetAttachmentsAsync(_cancel)).Length);
             Assert.AreEqual(null, content.Permissions);
 
             Assert.AreEqual("F2", contents[2].Key);
@@ -336,7 +339,7 @@ namespace SenseNet.IO.Tests
             Assert.AreEqual("F2", content.Name);
             Assert.AreEqual("Folder", content.Type);
             Assert.AreEqual(0, content.FieldNames.Length);
-            Assert.AreEqual(0, (await content.GetAttachmentsAsync()).Length);
+            Assert.AreEqual(0, (await content.GetAttachmentsAsync(_cancel)).Length);
             Assert.AreEqual(null, content.Permissions);
         }
         [TestMethod]
@@ -389,7 +392,7 @@ namespace SenseNet.IO.Tests
             Assert.AreEqual(1, content.FieldNames.Length);
             Assert.AreEqual("Binary", content.FieldNames[0]);
             Assert.AreEqual("F1.txt", ((JObject)content["Binary"])["Attachment"]?.Value<string>());
-            var attachments = await content.GetAttachmentsAsync();
+            var attachments = await content.GetAttachmentsAsync(_cancel);
             Assert.AreEqual(1, attachments.Length);
             Assert.AreEqual("Binary", attachments[0].FieldName);
             Assert.AreEqual("F1.txt", attachments[0].FileName);
@@ -452,7 +455,7 @@ namespace SenseNet.IO.Tests
             Assert.AreEqual("F1.txt", ((JObject)content["Binary"])["Attachment"]?.Value<string>());
             Assert.AreEqual("Bin2", content.FieldNames[1]);
             Assert.AreEqual("F1.txt.Bin2", ((JObject)content["Bin2"])["Attachment"]?.Value<string>());
-            var attachments = await content.GetAttachmentsAsync();
+            var attachments = await content.GetAttachmentsAsync(_cancel);
             Assert.AreEqual(2, attachments.Length);
             Assert.AreEqual("Binary", attachments[0].FieldName);
             Assert.AreEqual("F1.txt", attachments[0].FileName);

--- a/src/SenseNet.IO.Tests/FsWriterTests.cs
+++ b/src/SenseNet.IO.Tests/FsWriterTests.cs
@@ -92,7 +92,7 @@ namespace SenseNet.IO.Tests
                 _attachments = attachments;
             }
 
-            public Task<Attachment[]> GetAttachmentsAsync()
+            public Task<Attachment[]> GetAttachmentsAsync(CancellationToken cancel)
             {
                 foreach (var attachment in _attachments)
                 {

--- a/src/SenseNet.IO.Tests/Implementations/ContentNode.cs
+++ b/src/SenseNet.IO.Tests/Implementations/ContentNode.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SenseNet.IO.Tests.Implementations
@@ -27,7 +28,7 @@ namespace SenseNet.IO.Tests.Implementations
         public bool IsFolder => throw new NotImplementedException();
         public bool HasData => throw new NotImplementedException();
 
-        public Task<Attachment[]> GetAttachmentsAsync()
+        public Task<Attachment[]> GetAttachmentsAsync(CancellationToken cancel)
         {
             throw new System.NotImplementedException();
         }

--- a/src/SenseNet.IO.Tests/RepositoryReaderTests.cs
+++ b/src/SenseNet.IO.Tests/RepositoryReaderTests.cs
@@ -588,9 +588,9 @@ namespace SenseNet.IO.Tests
 
             expected = new[]
             {
-                "+InTree:'/Root/Content'",
-                "+InTree:'/Root/Content' -Path:'/Root/Content/Workspace-1/*' +Path:>'/Root/Content/Workspace-1/DocLib-1'",
-                "+InTree:'/Root/Content' +Path:>'/Root/Content/Workspace-2'",
+                "+InTree:'/Root/Content' | top:3, skip:0",
+                "+InTree:'/Root/Content' -Path:'/Root/Content/Workspace-1/*' | top:3, skip:0",
+                "+InTree:'/Root/Content' -Path:'/Root/Content/Workspace-1/*' | top:3, skip:3",
             };
             actual = reader.Queries.ToArray();
             AssertSequencesAreEqual(expected, actual);

--- a/src/SenseNet.IO/Extensions.cs
+++ b/src/SenseNet.IO/Extensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Http;
 using SenseNet.IO;
 using SenseNet.IO.Implementations;
 
@@ -46,6 +48,7 @@ namespace SenseNet.Extensions.DependencyInjection
         {
             services
                 .AddSenseNetClient()
+                .RemoveAll<IHttpMessageHandlerBuilderFilter>()
 
                 .AddTransient<IFilesystemReader, FsReader>()
                 .AddTransient<IFilesystemWriter, FsWriter>()

--- a/src/SenseNet.IO/IContent.cs
+++ b/src/SenseNet.IO/IContent.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace SenseNet.IO
 {
@@ -16,6 +17,6 @@ namespace SenseNet.IO
         public bool IsFolder { get; }
         public bool HasData { get; }
 
-        Task<Attachment[]> GetAttachmentsAsync();
+        Task<Attachment[]> GetAttachmentsAsync(CancellationToken cancel);
     }
 }

--- a/src/SenseNet.IO/Implementations/FsContent.cs
+++ b/src/SenseNet.IO/Implementations/FsContent.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -48,7 +49,7 @@ namespace SenseNet.IO.Implementations
         public bool HasData => !string.IsNullOrEmpty(_metaFilePath);
 
         private readonly string _defaultAttachmentPath;
-        public Task<Attachment[]> GetAttachmentsAsync()
+        public Task<Attachment[]> GetAttachmentsAsync(CancellationToken cancel)
         {
             if (_defaultAttachmentPath != null)
             {

--- a/src/SenseNet.IO/Implementations/FsWriter.cs
+++ b/src/SenseNet.IO/Implementations/FsWriter.cs
@@ -175,7 +175,7 @@ namespace SenseNet.IO.Implementations
 
         private async Task WriteAttachmentsAsync(string metaFileDir, IContent content, CancellationToken cancel)
         {
-            var attachments = await content.GetAttachmentsAsync();
+            var attachments = await content.GetAttachmentsAsync(cancel);
             foreach (var attachment in attachments.Where(a => a.Stream != null))
             {
                 var attachmentPath = Path.Combine(metaFileDir, attachment.FileName);

--- a/src/SenseNet.IO/Implementations/InitialContent.cs
+++ b/src/SenseNet.IO/Implementations/InitialContent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SenseNet.IO.Implementations
@@ -31,7 +32,7 @@ namespace SenseNet.IO.Implementations
             Type = type;
         }
 
-        public Task<Attachment[]> GetAttachmentsAsync()
+        public Task<Attachment[]> GetAttachmentsAsync(CancellationToken cancel)
         {
             return Task.FromResult(Array.Empty<Attachment>());
         }

--- a/src/SenseNet.IO/Implementations/RepositoryReader.cs
+++ b/src/SenseNet.IO/Implementations/RepositoryReader.cs
@@ -314,8 +314,6 @@ namespace SenseNet.IO.Implementations
             {
                 try
                 {
-//result = await RESTCaller.GetResponseStringAsync(RepositoryRootPath, "GetContentCountInTree",
-//    server: _repository.Server);
                     result = await _repository.GetResponseStringAsync(
                         new ODataRequest(_repository.Server) {Path = RepositoryRootPath, ActionName = "GetContentCountInTree"},
                         HttpMethod.Get, cancel);
@@ -335,7 +333,6 @@ namespace SenseNet.IO.Implementations
                     ActionName = "GetContentCountInTree",
                     ContentQuery = Filter
                 };
-//result = await RESTCaller.GetResponseStringAsync(req, server: _repository.Server);
                 result = await _repository.GetResponseStringAsync(req, HttpMethod.Get, cancel);
                 return int.TryParse(result, out var count2) ? count2 : default;
             }

--- a/src/SenseNet.IO/Implementations/RepositoryReaderContent.cs
+++ b/src/SenseNet.IO/Implementations/RepositoryReaderContent.cs
@@ -24,6 +24,7 @@ namespace SenseNet.IO.Implementations
 
         private readonly Dictionary<string, object> _fields;
         private readonly ServerContext _server;
+        private readonly IRepository _repository;
 
         public string[] FieldNames { get; }
         public string Name { get; set; }
@@ -45,6 +46,7 @@ namespace SenseNet.IO.Implementations
         public RepositoryReaderContent(Content content)
         {
             _server = content.Server;
+            _repository = content.Repository;
 
             Name = ((JToken)content["ContentName"]).Value<string>();
             Type = ((JToken)content["ContentType"]).Value<string>();
@@ -75,7 +77,7 @@ namespace SenseNet.IO.Implementations
             return value;
         }
 
-        public async Task<Attachment[]> GetAttachmentsAsync()
+        public async Task<Attachment[]> GetAttachmentsAsync(CancellationToken cancel = default)
         {
             var result = new List<Attachment>();
             foreach (var fieldName in FieldNames)
@@ -94,7 +96,7 @@ namespace SenseNet.IO.Implementations
                                 FileName = GetAttachmentName(fieldName),
                                 FieldName = fieldName,
                                 ContentType = contentType,
-                                Stream = await GetStream(uri)
+                                Stream = await GetStream(uri, cancel)
                             });
                         }
                     }
@@ -115,20 +117,28 @@ namespace SenseNet.IO.Implementations
             return attachmentName;
         }
 
-        public async Task<Stream> GetStream(string url)
+        public async Task<Stream> GetStream(string url, CancellationToken cancel)
         {
-            var absoluteUrl = _server.Url + url;
+//var absoluteUrl = _server.Url + url;
             MemoryStream result = null;
             try
             {
                 //TODO: return a stream that can handle huge files by downloading segments
                 // later, instead of storing the whole file in memory.
-                await RESTCaller.ProcessWebResponseAsync(absoluteUrl, HttpMethod.Get, _server, response =>
+//await RESTCaller.ProcessWebResponseAsync(absoluteUrl, HttpMethod.Get, _server, response =>
+//{
+//    result = new MemoryStream();
+//    response.Content.ReadAsStream().CopyTo(result);
+//    result.Seek(0, SeekOrigin.Begin);
+//}, CancellationToken.None);
+                await _repository.ProcessWebResponseAsync(url, HttpMethod.Get, null, null, 
+                    async (response, cancel) =>
                 {
                     result = new MemoryStream();
-                    response.Content.ReadAsStream().CopyTo(result);
+                    var stream = await response.Content.ReadAsStreamAsync(cancel);
+                    await stream.CopyToAsync(result, cancel);
                     result.Seek(0, SeekOrigin.Begin);
-                }, CancellationToken.None);
+                }, cancel);
             }
             catch (Exception e)
             {

--- a/src/SenseNet.IO/Implementations/RepositoryReaderContent.cs
+++ b/src/SenseNet.IO/Implementations/RepositoryReaderContent.cs
@@ -119,18 +119,11 @@ namespace SenseNet.IO.Implementations
 
         public async Task<Stream> GetStream(string url, CancellationToken cancel)
         {
-//var absoluteUrl = _server.Url + url;
             MemoryStream result = null;
             try
             {
                 //TODO: return a stream that can handle huge files by downloading segments
                 // later, instead of storing the whole file in memory.
-//await RESTCaller.ProcessWebResponseAsync(absoluteUrl, HttpMethod.Get, _server, response =>
-//{
-//    result = new MemoryStream();
-//    response.Content.ReadAsStream().CopyTo(result);
-//    result.Seek(0, SeekOrigin.Begin);
-//}, CancellationToken.None);
                 await _repository.ProcessWebResponseAsync(url, HttpMethod.Get, null, null, 
                     async (response, cancel) =>
                 {

--- a/src/SenseNet.IO/Implementations/RepositoryWriter.cs
+++ b/src/SenseNet.IO/Implementations/RepositoryWriter.cs
@@ -181,28 +181,24 @@ namespace SenseNet.IO.Implementations
                 .ToDictionary(fieldName => fieldName, fieldName => content[fieldName]);
 
             // Send "import" message
-            var body = "models=" + JsonConvert.SerializeObject(new[]
+            var body = new
+            {
+                path = repositoryPath,
+                data = new
                 {
-                    new
-                    {
-                        path = repositoryPath,
-                        data = new
-                        {
-                            ContentType = content.Type,
-                            ContentName = content.Name,
-                            Fields = fields,
-                            content.Permissions
-                        }
-                    }
+                    ContentType = content.Type,
+                    ContentName = content.Name,
+                    Fields = fields,
+                    content.Permissions
                 }
-            );
+            };
 
             // {path, name, type, action, brokenReferences, retryPermissions, messages };
             string resultString;
             try
             {
                 resultString = await _repository.InvokeActionAsync<string>(
-                    new OperationRequest {Path= "/Root",OperationName = "Import"}, cancel);
+                    new OperationRequest {Path= "/Root",OperationName = "Import", PostData = body}, cancel);
             }
             catch (Exception e)
             {
@@ -260,21 +256,17 @@ namespace SenseNet.IO.Implementations
                 .ToDictionary(fieldName => fieldName, fieldName => content[fieldName]);
 
             // Send "import" message
-            var body = "models=" + JsonConvert.SerializeObject(new[]
+            var body = new
+            {
+                path = repositoryPath,
+                data = new
                 {
-                    new
-                    {
-                        path = repositoryPath,
-                        data = new
-                        {
-                            ContentType = content.Type,
-                            ContentName = content.Name,
-                            Fields = fields,
-                            content.Permissions
-                        }
-                    }
+                    ContentType = content.Type,
+                    ContentName = content.Name,
+                    Fields = fields,
+                    content.Permissions
                 }
-            );
+            };
 
             // {path, name, type, action, brokenReferences, retryPermissions, messages };
             string resultString = null;
@@ -283,7 +275,7 @@ namespace SenseNet.IO.Implementations
                 await Retrier.RetryAsync(50, 3000, async () =>
                     {
                         resultString = await _repository.InvokeActionAsync<string>(
-                            new OperationRequest { Path = "/Root", OperationName = "Import" }, cancel);
+                            new OperationRequest {Path = "/Root", OperationName = "Import", PostData = body}, cancel);
                     },
                     (i, exception) => exception.CheckRetryConditionOrThrow(i), cancel);
 

--- a/src/SenseNet.IO/IoContent.cs
+++ b/src/SenseNet.IO/IoContent.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SenseNet.IO
@@ -25,7 +26,7 @@ namespace SenseNet.IO
         public bool IsFolder => throw new NotImplementedException("IsFolder is not implemented in IoContent.");
         public bool HasData => _fields.Any();
 
-        public Task<Attachment[]> GetAttachmentsAsync()
+        public Task<Attachment[]> GetAttachmentsAsync(CancellationToken cancel)
         {
             throw new NotImplementedException();
         }

--- a/src/SenseNet.IO/SenseNet.IO.csproj
+++ b/src/SenseNet.IO/SenseNet.IO.csproj
@@ -24,7 +24,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SenseNet.Client" Version="3.0.7" />
+    <PackageReference Include="SenseNet.Client" Version="4.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Rewrite breaking changes
- Debt worked off: Fix tests (see commit: Avoid using the buggy lucene's range query in export paging. (#65))
- Fix cutoff handling: Query the last block again with the new cutoff path
- Switch off the HttpClient's bulky logging.